### PR TITLE
Updated tag filtering and URL appends

### DIFF
--- a/staff_directory/templates/staff_directory/tags.html
+++ b/staff_directory/templates/staff_directory/tags.html
@@ -8,6 +8,8 @@
                 <li class="tag">
                     {% if tag.slug == selected_tags %}
                         <a href="{% url "staff_directory:remove_tag_from_filter" tag_slugs=selected_tags new_tag_slug=tag.slug %}" class="tag_name pushed" id="{{ tag.slug }}">{{ tag.name }}</a>
+                    {% elif tag.slug in selected_tags %}
+                        <a href="{% url "staff_directory:add_tag_to_filter" tag_slugs=selected_tags %}" class="tag_name pushed" id="{{ tag.slug }}">{{ tag.name }}</a>                         
                     {% else %}
                         <a href="{% url "staff_directory:add_tag_to_filter" tag_slugs=selected_tags new_tag_slug=tag.slug %}" class="tag_name" id="{{ tag.slug }}">{{ tag.name }}</a>
                     {% endif %}

--- a/staff_directory/templates/staff_directory/tags_by_category.html
+++ b/staff_directory/templates/staff_directory/tags_by_category.html
@@ -9,7 +9,7 @@
                 {{ tag_category_names|lookup:category }}
             </h4>
             <ul style="padding-left: 0px;">
-            {% for tag in c_tags %}
+            {% for tag in c_tags | slice:":10" %}
                 {% if selected_tags %}
                     <li class="tag">
                         {% if tag.slug in selected_tags %}

--- a/staff_directory/views.py
+++ b/staff_directory/views.py
@@ -347,7 +347,7 @@ def show_by_tag(req, tag_slugs='', new_tag_slug=''):
             STAFF_DIR_TAG_CATEGORIES).annotate(
                 tag_count=Count('taggit_taggeditem_items'),
             ). \
-            order_by('-tag_count', 'name')
+            order_by('-tag_count', 'name')[:30]
 
         title_tags = ','.join(t.name for t in selected_tags)
 


### PR DESCRIPTION
To resolve issues #6 and #7, added an issue limiter to the tag view and the category view. Also corrected behavior when clicking an existing tag so proper class is shown and additional parameters are no longer added to the URL string.
