### PR TITLE
Recent photos order by last updated

### DIFF
--- a/staff_directory/templates/staff_directory/directory.html
+++ b/staff_directory/templates/staff_directory/directory.html
@@ -10,8 +10,8 @@
         <div class="span8 right">
             <h2>Recently updated</h2>
             <div class="profile_images">
-                {% cache 600 staff_dir_random_photos %}
-                    {% for photo in random_photos %}
+                {% cache 600 staff_dir_recent_photos %}
+                    {% for photo in recent_photos %}
                         <a href="{% url "staff_directory:person" stub=photo.user.person.stub %}">
                             <img class="tiny_photo" src="{{ photo.photo_file.url_125x125 }}" alt="">
                             {{ photo.user.first_name }} {{ photo.user.last_name }}

--- a/staff_directory/views.py
+++ b/staff_directory/views.py
@@ -88,9 +88,9 @@ def index(req, format='html'):
     if not user_has_profile(req.user):
         return HttpResponseRedirect(reverse('core:register'))
     p = _create_params(req)
-    p['random_photos'] = Person.objects.filter(
+    p['recent_photos'] = Person.objects.filter(
         ~Q(photo_file="avatars/default.jpg")).filter(user__is_active=True). \
-        order_by('-user__date_joined')[:20]
+        order_by('-updated_at')[:20]
     p['divisions'] = OrgGroup.objects.filter(parent=None).order_by('title')
     p['offices'] = OrgGroup.objects.exclude(parent=None).order_by(
         'parent__title', 'title')


### PR DESCRIPTION
Currently, the 'recently updated' feed in Staff Directory is a list of the most recently created users.  Ideally this would order based on several criteria (profile change, staff thanks written, tag created, etc.).

The easiest improvement is to order on the last profile change.