### PR TITLE
Add ability to display alt phone on profile page

### DIFF
--- a/staff_directory/templates/staff_directory/profile.html
+++ b/staff_directory/templates/staff_directory/profile.html
@@ -27,21 +27,27 @@
             <a href="mailto:{{ person.user.email }}">{{ person.user.email }}</a>
           </li>
           <li class="info_phone">
-            <span>Phone</span>
-            {% if person.office_phone_formatted %}
-                {{ person.office_phone_formatted }}
-            {% else %}
-                Unlisted
-            {% endif %}
+              <span>Phone</span>
+          {% if person.office_phone_formatted %}
+              {{ person.office_phone_formatted }}
+          {% else %}
+              Unlisted
+          {% endif %}
           </li>
           <li class="info_mobile">
-            <span>Mobile</span>
-            {% if person.mobile_phone_formatted %}
-                {{ person.mobile_phone_formatted }}
-            {% else %}
-            Unlisted
-            {% endif %}
+              <span>Mobile</span>
+          {% if person.mobile_phone_formatted %}
+              {{ person.mobile_phone_formatted }}
+          {% else %}
+              Unlisted
+          {% endif %}
           </li>
+      {% if person.home_phone_formatted %}
+          <li class="info_phone">
+              <span>Alt</span>
+              {{ person.home_phone_formatted }}
+          </li>
+      {% endif %}
       </ul>
       <ul>
         {% if person.org_group.parent %}

--- a/staff_directory/templates/staff_directory/profile.html
+++ b/staff_directory/templates/staff_directory/profile.html
@@ -22,26 +22,24 @@
 
   <div class="list">
       <ul>
+      {% if person.user.email %}
           <li class="info_email">
-            <span>Email</span>
-            <a href="mailto:{{ person.user.email }}">{{ person.user.email }}</a>
+              <span>Email</span>
+              <a href="mailto:{{ person.user.email }}">{{ person.user.email }}</a>
           </li>
+      {% endif %}
+      {% if person.office_phone_formatted %}
           <li class="info_phone">
               <span>Phone</span>
-          {% if person.office_phone_formatted %}
               {{ person.office_phone_formatted }}
-          {% else %}
-              Unlisted
-          {% endif %}
           </li>
+      {% endif %}
+      {% if person.mobile_phone_formatted %}
           <li class="info_mobile">
               <span>Mobile</span>
-          {% if person.mobile_phone_formatted %}
               {{ person.mobile_phone_formatted }}
-          {% else %}
-              Unlisted
-          {% endif %}
           </li>
+      {% endif %}
       {% if person.home_phone_formatted %}
           <li class="info_phone">
               <span>Alt</span>


### PR DESCRIPTION
Depends on cfpb/collab#69 to actually have data to retrieve.

Before merging, would like to ask product owner if we can ditch the "Unlisted" business and just not output anything for all numbers that aren't there.