### PR TITLE
Support hiding of specific staff profiles

### DIFF
--- a/staff_directory/helpers.py
+++ b/staff_directory/helpers.py
@@ -7,6 +7,11 @@ STAFF_DIR_TAG_CATEGORIES = ['staff-directory-my-expertise',
                             'staff-directory-my-projects',
                             'staff-directory-other-things']
 
+def _apply_profile_filters(queryset):
+    return queryset.filter(user__is_active=True) \
+    .filter(hide_profile=False) \
+    .order_by('user__last_name', 'user__first_name') \
+    .select_related('user')
 
 def _set_remove_tag_permission(req, person, tags):
     user = person.user


### PR DESCRIPTION
See platform issue 2532 and related PR https://github.com/cfpb/collab/pull/74 (which should get merged in first so the migration can be applied).

@Scotchester and I paired on this. 

Since we needed to update several places where queries were being made, we created a new function `_apply_profile_filters` to reduce redundancy and encapsulate the logic for how profiles are displayed on directory pages.  We use the new `hide_profile` field introduced in https://github.com/cfpb/collab/pull/74 in this function to make sure we hide any specified profiles across different directory pages, as well as preventing the individual profile from loading.  However this does not yet prevent the profile from appearing in search results if you search for that person.
